### PR TITLE
Move schedule to subdir, add back DC26 schedule, add DC27 schedule

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,6 +7,6 @@ main:
    - title: "Project Blog"
      url: /projects.html
    - title: "Schedule"
-     url: /schedule.html
+     url: /schedule/schedule.html
    - title: "CFP"
      url: /CFP.html

--- a/schedule.md
+++ b/schedule.md
@@ -3,4 +3,166 @@ title: Schedule
 layout: page
 ---
 
-Check back in the future for an updated schedule!
+[Event schedule](#event-schedule)
+
+[Talk/Worshop schedule](#talkworkshop-schedule)
+
+[Talk/Workshop details](#talkworkshop-details)
+
+<br/>
+<br/>
+## Event schedule
+### Friday
+
+| Time | Events |
+|------|--------|
+| 1000 | HHV/SSV/BMCA Startup |
+| 1100 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1100 | DCG858/619 in the BMCA.
+| 1200 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1300 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1300 | Badge interfacing SPI/UART/I2C with MaraJade in the BMCA.
+| 1400 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1430 | How to make and order your first PCB! Working with KiCAD and PCB Houses With B1un7 and his Flying Badge in the BMCA.
+| 1500 | [Robo Sumo](/events/robosumo.html) in the HHV.
+| 1900 | HHV/SSV/BMCA Shutdown |
+
+### Saturday
+
+| Time | Events |
+|------|--------|
+| 1000 | HHV/SSV/BMCA Startup |
+| 1100 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1100 | How to make and order your first PCB! Working with KiCAD and PCB Houses With B1un7 and his Flying Badge in the BMCA.
+| 1200 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1200 | DCG858/619 in the BMCA.
+| 1300 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1300 | Identifying and sourcing electronic components in the BMCA.
+| 1400 | [SMD Soldering Challenge](/events/smdsolderchallenge.html) in the SSV.
+| 1400 | Making PCB Art with TwinkleTwinkie in the BMCA.
+| 1500 | [Robo Sumo: Hebocon Edition](/events/robosumo.html) in the HHV
+| 1900 | HHV/SSV/BMCA Shutdown |
+
+### Sunday
+
+| Time | Events |
+|------|--------|
+| 1000 | HHV/SSV/BMCA Startup |
+| 1030 | Breakfast at DEF CON 26: [Tindie](https://www.tindie.com/) x [Hackaday](https://hackaday.com/) Meetup in the BMCA
+|      | What better way to nurse your DEF CON hangover that with some strong coffee and pastries with the Hackaday and Tindie Crew? This year, we're super pleased that Hardware Hacking Village will be hosting us in the "Badge Maker's Community Area". Join us on Sunday morning at 10:30 am local time and bring along your hardware to show off! |
+| 1300 | HHV/SSV/BMCA Shutdown |
+
+<br/>
+<br/>
+## Talk/Workshop schedule
+### Friday
+
+|    Time     | Events |
+|-------------|--------|
+| 1000 ~ 1300 | Workshop - [Applied Physical Attacks on Embedded Systems, Introductory Version](#applied-physical-attacks-on-embedded-systems-introductory-version) |
+|             | Joe FitzPatriclk, @arinerron, and @pixieofchaos |
+| 1400 ~ 1800 | Workshop - [Getting to Blinky: #badgelife begins with a single blink](#getting-to-blinky-badgelife-begins-with-a-single-blink) |
+|             | Chris Gammell |
+
+### Saturday
+
+|    Time     | Events |
+|-------------|--------|
+| 1000 ~ 1040 | Talk - [Hacking your HackRF](#hacking-your-hackrf) |
+|             | Mike Davis |
+| 1100 ~ 1130 | Talk - [Disabling Intel ME in Firmware](#disabling-intel-me-in-firmware) |
+|             | Brian Milliron |
+| 1200 ~ 1250 | Talk - [NFC Payments: The Art of Relay & Replay Attacks](#nfc-payments-the-art-of-relay--replay-attacks) |
+|             | Salvador Mendoza |
+| 1500 ~ 1530 | Talk - [Breaking In: Building a home lab without having to rob a bank](#breaking-in-building-a-home-lab-without-having-to-rob-a-bank) |
+|             | Bryan Austin |
+| 1600 ~ 1630 | Talk - [The Cactus: 6502 Blinkenlights 40 Years Late](#the-cactus-6502-blinkenlights-40-years-late) |
+|             | Commodore Z
+| 1700 ~ 1720 | Talk - [WiFi Beacons will give you up](#wifi-beacons-will-give-you-up) |
+|             | John Aho |
+| 1800 ~ 1845 | Talk - [Building Drones the Hard Way](#building-drones-the-hard-way) |
+|             | David Melendez Cano |
+
+<br/>
+<br/>
+## Talk/Workshop details
+* * *
+### Applied Physical Attacks on Embedded Systems, Introductory Version
+Joe FitzPatriclk, @arinerron, and @pixieofchaos
+#### Abstract
+This workshop introduces several different relatively accessible interfaces on embedded systems. Attendees will get hands-on experience with UART, SPI, and JTAG interfaces on a MIPS-based wifi development board. After a brief architectural overview of each interface, hands-on labs will guide through the process understanding, observing, interacting with, and exploiting the interface to potentially access a root shell on the target.
+#### What to Bring
+No hardware or electrical background is required. Computer architecture knowledge, Linux internals, command-line familiarity, and low-level programming experience all very helpful but not actually required.
+
+All equipment, including laptops, will be provided for use in the class. Students will be provided with a lab manual that includes an equipment list of all materials used for the class.
+
+Max size: 24, first come first serve basis.
+#### Bio
+Joe (@securelyfitz) is an Instructor and Researcher at https://SecuringHardware.com (@securinghw). Joe has spent over a decade working on low-level silicon debug, security validation, and penetration testing of CPUS, SOCs, and microcontrollers. He has spent the past 5 years developing and leading hardware security related training, instructing hundreds of security researchers, pen testers, hardware validators worldwide. When not teaching Applied Physical Attacks training, Joe is busy developing new course content or working on contributions to the NSA Playset and other misdirected hardware projects, which he regularly presents at all sorts of fun conferences.
+
+@arinerron is a student, security enthusiast, CTF player, bug bounty hunter, software developer, and ham radio operator (K1ARE). He's interested in many aspects of security, though most of his experience is in web and binary exploitation.
+
+Chaos Pixie (@pixieofchaos) works for the man doing embedded systems security.
+* * *
+### Getting to Blinky: #badgelife begins with a single blink
+Chris Gammell
+#### Abstract
+This is an in-person, hands-on version of "Getting To Blinky", an online course series that has taught thousands to use the free and open source electronics CAD program, KiCad. This would be a "DEFCON badge" version of that course which showcases how to add a blinking circuit, get acquainted with the tool and also add customizable artwork to a Printed Circuit Board (PCB). By the end, attendees will be able to actually order a low cost PCB from online sources.
+#### What to Bring
+Please come to this session with a computer with KiCad set up and running.  Course is aimed at KiCad 4.0.7, slightly earlier is fine but 5.0.0 is not advised. Install assistance can be given during the beginning of the presentation if needed.
+
+Max size: 24, first come first serve basis.
+#### Bio
+Chris Gammell is the host of The Amp Hour Electronics podcast and the owner of Contextual Electronics, an online apprenticeship program. He has been teaching people to design and build electronics online for 8 years, including 5 as an online instructor. His interests are in hands on education and making the electronics learning process easier. He also focuses on low cost and no cost tools, like the open source CAD program KiCad. Prior to teaching online, Chris was an electronics designer for 15 years in various industrial settings.
+* * *
+### Hacking your HackRF
+Mike Davis
+#### Abstract
+The HackRF isn't just an SDR - it's an open-source, open-hardware device that's designed to be modified. In this talk I walk through the basics of how to open and modify the hardware and software. I also show all the mods and hacks I've done to/with my HackRFs, including physical synchronisation between HackRFs, quadcopter transmitter adaptation, audio encoding/decoding, quadcopter vtx and a future project to add USB3
+#### Bio
+Software/hardware developer, currently studying an MSc Computer Science (infosec), not yet a cyborg
+* * *
+### Disabling Intel ME in Firmware
+Brian Milliron
+#### Abstract
+Modern OSes have consistently raised the bar in regards to security with each revision, largely due to the efforts of the security community to find and report bugs.  Because of this the OS layer is reasonably secure at this point.  However the security of the hardware layer has fallen far behind and now represents the biggest threat.  In particular, the Intel Management Engine is a huge security hole which Intel has put great effort into forcing users to accept blindly.  No more.  This talk will present a how to on permanently disabling Intel ME by reflashing the BIOS using a Raspberry Pi.  Take back control of your own hardware and give Big Brother's Backdoor the boot.
+#### Bio
+Brian Milliron works as a freelance penetration tester for ECR Security.  He has been monkeying around with security since his teens and has worked as a pentester for the last 8 years, working primarily with the Energy/Utility sector.  Besides popping shells and defeating Big Brother technology, he also enjoys exploring the RF spectrum, finding new uses for Raspberry Pis, studying malware, nature and off-grid living.
+* * *
+### NFC Payments: The Art of Relay & Replay Attacks
+Salvador Mendoza
+#### Abstract
+Relay and replay attacks are becoming more common in the payment industry. Getting more complex and sophisticated day by day. We are not just seeing simple skimming techniques but complex attack vectors that are a combination of technologies and implementations involving SDR(Software-Defined Radio), NFC, APDU(Application Protocol Data Unit), hardware emulation design, specialized software, tokenization protocols and social engineering.  In this talk, we will discuss what these attacks are, or what kind of hardware or software could be implemented.
+#### Bio
+Salvador Mendoza is a security researcher focusing in tokenization processes, magnetic stripe information and embedded prototypes. He has presented on tokenization flaws and payment methods at Black Hat USA, DEF CON 24/25, DerbyCon, Ekoparty, BugCON, 8.8, and Troopers 17/18. Salvador designed different tools to pentest magnetic stripe information and tokenization processes. In his designed toolset includes MagSpoofPI, JamSpay, TokenGet, SamyKam and lately BlueSpoof.
+* * *
+### Breaking In: Building a home lab without having to rob a bank
+Bryan Austin
+#### Abstract
+Building a home lab is critical to making you as a hacker better, but between space, hardware costs and learning it can quickly become an expensive habit. This talk will aim to show you some of the low cost options to learning the skills of the trade, and a bit of the mindset you need to finish that project.
+#### Bio
+Bryan Austin is an information security researcher with a background in electronics, threat analysis, social engineering, working with at-risk children, mentorship and research. He is also the co-founder of Through the Hacking Glass, a free mentorship community partnered with Peerlyst. By day, he secures people and organizations against scammers and hackers but by night he works with children with behavioral issues and a variety of other challenges. When not crusading against internet evil doers, he enjoys hiking, Taekwondo, and hacking with his beautiful wife and 3 amazing children.
+* * *
+### The Cactus: 6502 Blinkenlights 40 Years Late
+Commodore Z
+#### Abstract
+While many machines prior to the microcomputer boom of 1977 were commonly found with front panel interfaces and blinkenlights, only a few obscure examples use a 6502 microprocessor.  What seemed like a perfect blend of inexpensive computer technologies didn't mix well in practice, thus kits and the majority of homebrew machines opted for other microprocessor/interface combinations.  Building a computer from the ground up around a microprocessor was a process worth exploring, so why not approach it from a historical perspective?  Enter the Cactus: a technological “what if” built with the goal of recreating the homebrew computer experience of the 1970s. This includes parts and construction techniques of the era, with only a few post-1980 concessions where appropriate. I will describe the process involved in making a 1970s homebrew computer ~40 years too late, as well as why such a machine never could have come to be in the era it was designed to mimic.
+#### Bio
+Commodore Z is vintage computer geek by night, and a broadcast engineer by day.  He collects and restores vintage computers & robots, studies historical telephony, and peers into the past to better understand the future.  He lives by the mantra "jack of all trades, master of none, but better than a master of one", and doctors say there are traces of blood in his lead stream.  When time permits, he volunteers for the Vintage Computer Federation.
+* * *
+### WiFi Beacons will give you up
+John Aho
+#### Abstract
+A quick and dirty intro to making wifi beacons with esp8266 modules. A new small tool to help you generate your own beacon and unveiling of a fun multi-beacon setup.
+#### Bio
+John is a programmer who makes gloriously useless things and occasionally useful ones by accident.
+* * *
+### Building Drones the Hard Way
+David Melendez Cano
+#### Abstract
+Drones are now "the sexy technology" but few people really know what kind of algorithms and hardware mix is involved.
+
+This talk will show the roadmap of building two homemade drones, built from scratch. No ardupilot/pilot boards was used to develop this project. Topics like real time scheduling on Linux, DeviceTree configuration, I2C bitbanging , Attitude estimation and PID control functions will be covered.
+#### Bio
+David Melendez, Spain, works as R&D software engineer for TV Studio manufacturer company, Albalá Ingenieros S.A. in Madrid. He has won several prices in robotic contests and he has been a speaker at Nuit Du Hack, RootedCON, NoConName,  Codemotion, HKOSCON, etc. Author of the book "Hacking con Drones" and robot builder.
+* * *

--- a/schedule/dc26-schedule.md
+++ b/schedule/dc26-schedule.md
@@ -1,5 +1,5 @@
 ---
-title: Schedule
+title: DC26 Schedule
 layout: page
 ---
 

--- a/schedule/schedule.md
+++ b/schedule/schedule.md
@@ -1,0 +1,158 @@
+---
+title: DC27 Schedule
+layout: page
+---
+
+[Event Schedule](#event-schedule)
+
+[Talk/Workshop schedule](#talkworkshop-schedule)
+
+[Talk/Workshop Details](#talkworkshop-details)
+
+<br/>
+<br/>
+## Event Schedule
+### Friday
+
+| Time | Events |
+|------|--------|
+| 1000 | HHV/SSV Startup |
+| 1800 | HHV/SSV Shutdown |
+
+### Saturday
+
+| Time | Events |
+|------|--------|
+| 1000 | HHV/SSV Startup |
+| 1800 | HHV/SSV Shutdown |
+
+### Sunday
+
+| Time | Events |
+|------|--------|
+| 1000 | HHV/SSV Startup |
+| 1300 | HHV/SSV Shutdown |
+
+<br/>
+<br/>
+## Talk/Workshop Schedule
+### Friday
+
+| Time      | Events | Location |
+|-----------|--------|----------|
+| 1000~1050 | Talk - [Reversing Corruption In Seagate Hdd Translators, The Naked Trill Data Recovery Project](#reversing-corruption-in-seagate-hdd-translators-the-naked-trill-data-recovery-project) | Bally's Event Villages Track 1 (Just outside the HHV)|
+| 1100~1150 | Talk - [Another Car Hacking Approach](#another-car-hacking-approach) | Bally's Event Villages Track 1 (Just outside the HHV) |
+| 1100~1250 | Workshop - [Rapid Prototyping For Badges](#rapid-prototyping-for-badges) | Inside HHV, Workshop Area |
+| 1200~1230 | Talk - [Infrared: New Threats Meet Old Devices](#infrared-new-threats-meet-old-devices) | Bally's Event Villages Track 1 (Just outside the HHV) |
+| 1400~1450 | Talk - [Making A Less Shitty Sao: How To Use Kicad To Build Your First Pretty Pcb](#making-a-less-shitty-sao-how-to-use-kicad-to-build-your-first-pretty-pcb) | Inside HHV, Workshop Area |
+| 1500~1550 | Talk - [Ebolaphone Or Bust](#ebolaphone-or-bust) | Inside HHV, Workshop Area |
+
+### Saturday
+
+| Time      | Events | Location |
+|-----------|--------|----------|
+| 1100~1150 | Talk - [Understanding & Making Pcb Art](#understanding--making-pcb-art) | Inside HHV, Workshop Area |
+| 1200~1250 | Talk - [What You Print Is Not What You Get Anymore: Mitm Attack On 3D Printers Network Communications](#what-you-print-is-not-what-you-get-anymore-mitm-attack-on-3d-printers-network-communications) | Inside HHV, Workshop Area |
+| 1700~1750 | Followup - [Fireside Chat Style Followup To Main Track Talk: Tag-side attacks against NFC](https://defcon.org/html/defcon-27/dc-27-speakers.html#Wade) Bring your questions, get some answers. | Inside HHV, Workshop Area |
+
+## Talk/Workshop Details
+* * *
+### Reversing Corruption In Seagate Hdd Translators, The Naked Trill Data Recovery Project
+Allison Marie Naaktgeboren MrDe4d
+
+#### Abstract
+Translation tables are a dynamic component of HDD firmware that translate logical addresses to physical locations on the disk. Corrupted translators can be the cause of drive failures in drives that appear undamaged and are without physical trauma. That failure can be reversed in many cases. We will present ways to identify if a drive’s translator has been corrupted for the Moose & Pharaoh drive families specifically, how to force a translator rebuild, and open source tool(s) to help you repair the translator.
+
+Data recovery is a notoriously secretive field. Very little information about firmware and its internal data structures is public. Knowledge should be open source. By sharing what we’ve learned we hope to open this field up to more people, encourage repair, encourage re-use rather than disposal of hard drives, and encourage further publicly shared research.  After the talk, attendees should be able to fix this type of error themselves in HDDs of the appropriate families using a TTL converter and the supplied code. Familiarity with the basic components of hard drive firmware is helpful, but not required.
+
+#### Bio
+MrDe4d is the lead Data Recovery Engineer and founder of Revenant Data Recovery. She is also a hobbyist embedded systems security researcher. She leads local workshops in Binary and Assembly CTF challenges. She has presented at conferences such as HushCon and Teardown, as well as at other hackerspaces around the USA.  In 2017 she co-founded PASCAL Hackerspace and in 2019 co-founded the QultoftheQuantumQapybaras CTF team. She is passionate about learning, freedom of information, promoting self-advocacy, and hacking the planet!
+
+Allison Marie Naaktgeboren is a Software Engineer with security roots at Signal Sciences. She has written and regretted code at Mozilla, Amazon, Cisco, FactSet Research Systems, and the Biorobotics Laboratory of the Robotics Institute.  She holds a Bachelor’s Degree in Computer Science from Carnegie Mellon University. Allison leads classes on computer science fundamentals, cofounded & captains the QultoftheQuantumQapybaras CTF team, and mentors disadvantaged high school students in robotics, software, and hardware hacking.
+* * *
+### Another Car Hacking Approach
+Benjamin Lafois Vladan Nikolic
+
+#### Abstract
+Cars now have infotainment systems for several years. Those systems accomplish basic tasks such as radio, music, navigation and Bluetooth handsfree, but can also embed sophisticated features, using wireless connectivity (with cloud backends) and vehicle bus connectivity. Previous talks have presented some vulnerabilities in the past. This talk will introduce a different approach to compromise embedded infotainment systems, with both software and hardware attacks. 
+
+While previous methods focused on OS and network hacking (access to DBus, telnet, firmware update mechanism…), those vulnerabilities do not exist anymore and different approach had to be used, using 3rd party applications. Multiple protections had to be bypassed, such as multiple level of signature (installation package, code-signing), and read-only file systems just to name few.
+Post-exploitation forensics demonstrated that the vulnerabilities identified would likely be exploited in many different cars.
+
+How to proceed to test such systems? What are the steps to compromise infotainment system and what vulnerabilities can be found and exploited?
+
+#### Bio
+Benjamin Lafois is a senior security consultant that has been working in IT security and compliance for more than 10 years. Benjamin is an expert penetration tester on distributed systems as well as modern infrastructures such as IoT, embedded devices and OT systems.
+Benjamin has identified several zero-day vulnerabilities on IoT and ICS devices.  He has been involved on critical projects in Oil & Gas projects. 
+He also has application assessment expertise and is a Java-guru. 
+
+* * *
+### Rapid Prototyping For Badges
+Securelyfitz and friends
+
+#### Abstract
+Messy wires can get the job done, but leveling up your hardware hacking sometimes requires some custom circuit boards.
+This workshop will be a crash course in rapid prototyping for hardware hacking. We'll start you off with a complete schematic for flashing some LEDs. After a brief lecture about how PCBs are made, you'll get to adjust your schematic, layout components in Eagle or KiCAD PCB layout software, and customize it with some artwork. With help, you'll manufacture a PCB on a PCB Mill, and if time permits you can assemble it in class or bring it to the HHV/SSV to assemble.
+
+You'll walk away with your own custom PCB badge with flashy lights and a better understanding of how to make your own custom PCBs in the future.
+
+#### Bio
+Joe FitzPatrick (@securelyfitz) is an Instructor and Researcher at SecuringHardware.com. Joe has spent over a decade working on low-level silicon debug, security validation, and penetration testing of CPUS, SOCs, and microcontroller. He has spent the past 5 years developing and leading hardware security-related training, instructing hundreds of security researchers, pen-testers, hardware validators worldwide. When not teaching classes on applied physical attacks, Joe is busy developing new course content or working on contributions to the NSA Playset and other misdirected hardware projects, which he regularly presents at all sorts of fun conferences.
+
+* * *
+### Infrared: New Threats Meet Old Devices
+Wang Kang
+
+#### Abstract
+Before the Bluetooth technology kicks in, infrared remote control has been widely used. Many systems still use IR as their control interface. With the proliferation of new smart devices with IR-related components, such as face recognition systems, night vision infrared cameras, slow motion cameras, etc., this ancient technology may bring some new attack surfaces.
+
+First, we will demonstrate a new attack scenario. After a COTS security camera is pwned through Internet, the infrared night vision fill light could be flashed to control devices such as TV and AC. In this way, dumb devices that were originally considered to be air-gapped will also face security threats from the network side. With much greater TX power, larger area could be influenced. Additional attack surfaces will also be discussed. 
+
+Second, we will demonstrate the use of an electric drill and a pure mechanical design similar to a fan blade, constructed as a Spatial Light Modulator. We will demonstrate how to construct a remote control signal that can be recognized by COTS IR remote control from still infrared light. Who said hacking an electric fan doesn't matter?  
+
+Third, we will analyze the frame structure of an infrared remote control signal by utilizing a smartphone with 960fps 'Super Slow-mo' function as a poor man's logic analyzer.  
+
+#### Bio
+Wang Kang is a Security Expert of Alibaba Group, focusing on security issues of IoT, cyber-physical system, V2X, and trusted computing. He is a contributor of Linux Kernel, (TDD-LTE USB Dongle support) as well as a founder of the Tsinghua University Network Administrators. He was a speaker at Black Hat {Europe 2015, USA 2017, USA 2018, Asia 2019}, Virus Bulletin 2018, HITB {Dubai 2018, AMS 2019}.
+
+* * *
+### Making A Less Shitty Sao: How To Use Kicad To Build Your First Pretty Pcb
+Steve Ball (hamster)
+
+#### Abstract
+SAOs are everywhere at Defcon, but for many, it's hard to imagine how to design and manufacture them.  In this talk, we'll go through the process of taking artwork to a final PCB that is ready to order.  Along the way we'll talk about different PCB layers and their effects in art, schematic capture, and options available at the board house.
+
+#### Bio
+hamster has been making badges for dczia and dc801 for the last 5 years, and has been an all-around hardware hacker for many more.  He enjoys bending commercial design software to the silly and open sourcing the result.
+
+* * *
+### Ebolaphone Or Bust
+SciaticNerd
+
+#### Abstract
+We should all invest in being lifelong learners. That much is a given. When challenged to come up with something new for a boss’s Summer Project, I combined my love of hunting for hardware with some software learning to set up my own phone system. This kicked off an adventure in questing for hardware and figuring out how to set things up. Expect to hear about how to find things, how simple is sometimes better, and we’ll even risk a live demo of how to prep and get ready to deploy one of the phones!
+
+#### Bio
+SciaticNerd has been working in the field of Digital Identity since 2002, first as a trainer, then advancing to trusted and engineering roles. Along the way he's connected with people in the computing community who have a passion for helping others to learn and grow. He speaks and volunteers at several conferences, coordinates the San Antonio, Texas BSides conference, and attends and contributes to local groups. He also promotes and discusses involvement with computing, security, privacy, technology related activities through podcasts like Security Endeavors, Hackers with Bourbon, Grumpy Hackers, DangerousMinds, and others.
+
+* * *
+### Understanding & Making Pcb Art
+TwinkleTwinkie
+
+#### Abstract
+PCB Art is all over DEF CON and for some attendees one of their primary goals is to see, admire, and collect some of the dozens of stunning examples of PCB Art that premieres at DEF CON every year.  In this talk I will walk you through an explanation of what a PCB is, how it's made, how PCB Artists use the limitations of the PCB Manufacturing process to produce stunning artwork and finally how you can make your own PCB Art using Inkscape & KiCAD.  This talk is intended for anyone who appreciates PCB Art, wants to make their own PCB Art, or just wants to know how the sausage gets made.
+
+#### Bio
+TwinkleTwinkie is an independent PCB Artist and has manufactured dozens of Artistic PCB Badges & Indie Badge Addons. His work was featured in Hackaday’s 2018 “Badge Life” Documentary. Some of his notable works that he has produced are: Arc Badge, BSides Vancouver 2019 Badge, BSides Atlanta 2019 Badge, Queercon 15 Badge Top Board & Access Pass, Krusty the It "SAO", Prince & Pharoah OSHCat "SAO" for OSHPark, the Cheshire Cat "SAO", and the Chestoro "SAO".
+
+* * *
+### What You Print Is Not What You Get Anymore: Mitm Attack On 3D Printers Network Communications
+Hamza Alkofahi
+
+#### Abstract
+Additive Manufacturing (AM) and 3D Printing were conceived to reduce the cost of the prototyping process. Over time,  these technologies became faster, more accurate, and much more affordable.  All of these factors, as well as the potential to use AM in production parts and systems,  have helped rapidly drive the growth of AM in both industrial and personal uses.  Thus, there is a concomitant demand to understand the implications of cybersecurity in this field and these systems. In our research, we show how manufacturers of high-end 3D printers failed to protect the confidentiality and integrity of the printed 3D models. Also, our proof of concept demonstrates how network attacks (such as MITM) on 3D printers communication channels can cause a massive impact (such as stealing, replacing or even sabotaging models) on the whole printing process.
+
+#### Bio
+Hamza is a cybersecurity researcher and a white-hat hacker, currently doing his Ph.D. at Auburn University. He is interested in vulnerability assessment, reverse engineering, and detecting business logic vulnerabilities. He developed the first parser for a closed source file format (CMB) also built an automated system for detecting vulnerabilities in critical infrastructure websites.
+
+* * *

--- a/schedule/schedule.md
+++ b/schedule/schedule.md
@@ -41,19 +41,28 @@ layout: page
 | Time      | Events | Location |
 |-----------|--------|----------|
 | 1000~1050 | Talk - [Reversing Corruption In Seagate Hdd Translators, The Naked Trill Data Recovery Project](#reversing-corruption-in-seagate-hdd-translators-the-naked-trill-data-recovery-project) | Bally's Event Villages Track 1 (Just outside the HHV)|
+|           | Allison Marie Naaktgeboren, MrDe4d | |
 | 1100~1150 | Talk - [Another Car Hacking Approach](#another-car-hacking-approach) | Bally's Event Villages Track 1 (Just outside the HHV) |
+|           | Benjamin Lafois, Vladan Nikolic | |
 | 1100~1250 | Workshop - [Rapid Prototyping For Badges](#rapid-prototyping-for-badges) | Inside HHV, Workshop Area |
+|           | Securelyfitz and friends | |
 | 1200~1230 | Talk - [Infrared: New Threats Meet Old Devices](#infrared-new-threats-meet-old-devices) | Bally's Event Villages Track 1 (Just outside the HHV) |
+|           | Wang Kang | |
 | 1400~1450 | Talk - [Making A Less Shitty Sao: How To Use Kicad To Build Your First Pretty Pcb](#making-a-less-shitty-sao-how-to-use-kicad-to-build-your-first-pretty-pcb) | Inside HHV, Workshop Area |
+|           | Steve Ball (hamster) | |
 | 1500~1550 | Talk - [Ebolaphone Or Bust](#ebolaphone-or-bust) | Inside HHV, Workshop Area |
+|           | SciaticNerd | |
 
 ### Saturday
 
 | Time      | Events | Location |
 |-----------|--------|----------|
 | 1100~1150 | Talk - [Understanding & Making Pcb Art](#understanding--making-pcb-art) | Inside HHV, Workshop Area |
+|           | TwinkleTwinkie | |
 | 1200~1250 | Talk - [What You Print Is Not What You Get Anymore: Mitm Attack On 3D Printers Network Communications](#what-you-print-is-not-what-you-get-anymore-mitm-attack-on-3d-printers-network-communications) | Inside HHV, Workshop Area |
+|           | Hamza Alkofahi | |
 | 1700~1750 | Followup - [Fireside Chat Style Followup To Main Track Talk: Tag-side attacks against NFC](https://defcon.org/html/defcon-27/dc-27-speakers.html#Wade) Bring your questions, get some answers. | Inside HHV, Workshop Area |
+|           | Christopher Wade | |
 
 ## Talk/Workshop Details
 * * *


### PR DESCRIPTION
Would like double check of this.

All of the Bio's and Abstract's are provided directly by speakers. Not sure if we should edit them since that takes some time and it was already verified that is how they want that information to appear.

I double checked the talk schedule, but if anyone else wants to as well, the spreadsheet is in the shared drive under DC27.